### PR TITLE
Recursive scan extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The returned EventEmitter emits the following events:
 const params = {
   TableName : 'MyTable'
 }
-const emitter = await documentClient.scanStream(params)
+const emitter = documentClient.scanStream(params)
 emitter.on('items', async (items) => {
   console.log(items)
 })
@@ -121,7 +121,7 @@ The returned EventEmitter emits the following events:
 const params = {
   TableName : 'MyTable'
 }
-const emitter = await documentClient.scanStreamSync(params)
+const emitter = documentClient.scanStreamSync(params)
 emitter.on('items', async (items) => {
   // Do something async with the documents
   return Promise.all(items.map((item) => sendItemToSantaClaus(item)))

--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ const data = await documentClient.get(regularDynamoParams)
 
 - automatically appends .promise()
 - automatically retries and backs off when you get throttled
-- new methods for scan() operations
+- new methods for scan operations
+  - [scanAll(params)](#methods-scanall)
+  - [scanStream(params)](#methods-scanstream)
+  - [scanStreamSync(params)](#methods-scanstreamsync)
 
-## .promise() by default
+## Promises by default
+
+The DynamoPlus client will automatically append `.promise()` for you, making all methods awaitable by default.
 
 When the client is instantiated, the original methods are prefixed and accessible through e.g. ``original_${method}``
 
-## retries and backoff
+## Retries and backoff
 
 Whenever a query fails for reasons such as `LimitExceededException` the promise will reboot behind the scenes so that you don't have to worry about it.
 
@@ -49,8 +54,8 @@ If you want to use a delay from the beginning, set `lastBackOff` to a millisecon
 
 We've supercharged _scan()_ for those times when you want to recurse through entire tables.
 
-<a name="methods-all"></a>
-### all(params)
+<a name="methods-scanall"></a>
+### scanAll(params)
 
 - **params** - [AWS.DynamoDB.DocumentClient.scan() parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
 
@@ -60,18 +65,18 @@ const params = {
   FilterExpression : 'Year = :this_year',
   ExpressionAttributeValues : {':this_year' : 2015}
 }
-const response = await documentClient.all(params)
+const response = await documentClient.scanAll(params)
 // response now contains ALL documents from 2015, not just the first 1MB
 ```
 
 ---
 
-<a name="methods-stream"></a>
-### stream(params)
+<a name="methods-scanstream"></a>
+### scanStream(params)
 
 An EventEmitter-driven approach to recursing your tables. This is a powerful tool when you have datasets that are too large to keep in memory all at once.
 
-**Note:** stream() does not care whether your event listeners finish before it requests the next batch. (It will, however, respect throttling exceptions from DynamoDB.) If you want to control the pace, see [`streamSync()`](#methods-streamsync)
+**Note:** scanStream() does not care whether your event listeners finish before it requests the next batch. (It will, however, respect throttling exceptions from DynamoDB.) If you want to control the pace, see [scanStreamSync](#methods-streamsync).
 
 - **params** - [AWS.DynamoDB.DocumentClient.scan() parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
 
@@ -86,7 +91,7 @@ The returned EventEmitter emits the following events:
 const params = {
   TableName : 'MyTable'
 }
-const emitter = await documentClient.stream(params)
+const emitter = await documentClient.scanStream(params)
 emitter.on('items', async (items) => {
   console.log(items)
 })
@@ -94,10 +99,10 @@ emitter.on('items', async (items) => {
 
 ---
 
-<a name="methods-streamsync"></a>
-### streamSync(params)
+<a name="methods-scanstreamsync"></a>
+### scanStreamSync(params)
 
-Like `stream()`, but will not proceed to request the next batch until all eventlisteners have returned a value (or resolved, if they return a Promise).
+Like `scanStream()`, but will not proceed to request the next batch until all eventlisteners have returned a value (or resolved, if they return a Promise).
 
 - **params** - [AWS.DynamoDB.DocumentClient.scan() parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
 
@@ -112,11 +117,11 @@ The returned EventEmitter emits the following events:
 const params = {
   TableName : 'MyTable'
 }
-const emitter = await documentClient.streamSync(params)
+const emitter = await documentClient.scanStreamSync(params)
 emitter.on('items', async (items) => {
   // Do something async with the documents
   return Promise.all(items.map((item) => sendItemToSantaClaus(item)))
-  // Once the Promise.all resolves, streamSync() will automatically request the next batch.
+  // Once the Promise.all resolves, scanStreamSync() will automatically request the next batch.
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ const response = await documentClient.all(params)
 // response now contains ALL documents from 2015, not just the first 1MB
 ```
 
+---
+
 <a name="methods-stream"></a>
 ### stream(params)
 
@@ -89,6 +91,8 @@ emitter.on('items', async (items) => {
   console.log(items)
 })
 ```
+
+---
 
 <a name="methods-streamsync"></a>
 ### streamSync(params)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,6 +442,21 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz",
+      "integrity": "sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==",
+      "dev": true,
+      "requires": {
+        "@types/jest-diff": "*"
+      }
+    },
+    "@types/jest-diff": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
+      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.4",
+  "version": "1.1.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.3",
+  "version": "1.1.0-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.0.2",
+  "version": "1.1.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.2",
+  "version": "1.1.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.4",
+  "version": "1.1.0-rc.5",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.3",
+  "version": "1.1.0-rc.4",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.0.2",
+  "version": "1.1.0-rc.1",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.2",
+  "version": "1.1.0-rc.3",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-plus",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "description": "dynamo-plus",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "repository": "github:Sleavely/dynamo-plus",
   "license": "MIT",
   "devDependencies": {
+    "@types/jest": "^24.0.13",
     "aws-sdk": "^2.455.0",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",

--- a/src/clientMethods.spec.js
+++ b/src/clientMethods.spec.js
@@ -6,6 +6,7 @@ it('exposes a list of methods to mutate', () => {
   expect(methods).toBeInstanceOf(Array)
 })
 
+// Dont want to modify something that isn't actually a real method
 it.each(methods)('%s() exists on DocumentClient', (method) => {
   expect(DocumentClient.prototype).toHaveProperty(method)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,17 @@ const {
   autoRetry,
   retryableExceptions,
 } = require('./retryableExceptions')
+const {
+  appendAll,
+  appendStream
+} = require('./scanExtensions')
 
 const clientConstructor = (options = {}) => {
   const dynamoClient = new DynamoDB.DocumentClient(options)
   promisifyDocumentClient(dynamoClient)
   autoRetry(dynamoClient)
+  appendAll(dynamoClient)
+  appendStream(dynamoClient)
   return dynamoClient
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,13 @@ const {
   autoRetry,
   retryableExceptions,
 } = require('./retryableExceptions')
-const {
-  appendAll,
-  appendStream
-} = require('./scanExtensions')
+const appendScanExtentions = require('./scanExtensions')
 
 const clientConstructor = (options = {}) => {
   const dynamoClient = new DynamoDB.DocumentClient(options)
   promisifyDocumentClient(dynamoClient)
   autoRetry(dynamoClient)
-  appendAll(dynamoClient)
-  appendStream(dynamoClient)
+  appendScanExtentions(dynamoClient)
   return dynamoClient
 }
 

--- a/src/retryableExceptions.js
+++ b/src/retryableExceptions.js
@@ -13,13 +13,23 @@ const retryableExceptions = [
 
 const autoRetry = (client) => {
   clientMethods.forEach((method) => {
+    // Save a reference to the unmutated version of the method.
+    // We're not storing it on the client as a prop since
+    // it is probably not the original original.
+    const originalMethod = client[method]
+
     client[method] = async (params = {}) => {
-      return client[method](params).catch((err) => {
-        if (retryableExceptions.some((retry) => [err.constructor.name, err.name].includes(retry))) {
+      return originalMethod(params).catch((err) => {
+        const retryableException = retryableExceptions.find((retry) => [err.constructor.name, err.name].includes(retry))
+
+        if (retryableException) {
+          // Back off by 150% every time,
+          // starting at 1 sec and a maximum of 30 sec between tries.
           params.lastBackOff = params.lastBackOff ? Math.min(Math.floor(params.lastBackOff * 1.5), 30000) : 1000
           return sleep(params.lastBackOff)
             .then(() => client[method](params))
         }
+
         // Non-retryable exceptions (like ValidationException) should incur actual error propagation
         throw err
       })

--- a/src/retryableExceptions.spec.js
+++ b/src/retryableExceptions.spec.js
@@ -1,0 +1,121 @@
+
+jest.doMock('./utils/sleep', () => jest.fn(async (input) => input))
+const sleep = require('./utils/sleep')
+
+jest.doMock('./clientMethods', () => ['attack'])
+const methods = require('./clientMethods')
+
+const mockClient = (method = 'attack') => {
+  const methodMock = jest.fn(async () => 1337)
+  return {
+    mockReference: methodMock,
+    methodName: method,
+    [method]: methodMock,
+  }
+}
+
+const {
+  autoRetry,
+  retryableExceptions,
+} = require('./retryableExceptions')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('autoRetry is a function', () => {
+  expect(autoRetry).toBeInstanceOf(Function)
+})
+
+it('autoRetry() mutates the client', async () => {
+  expect.assertions(methods.length)
+  methods.forEach((method) => {
+    const client = mockClient(method)
+
+    const preMutated = client[method].toString()
+    autoRetry(client)
+    const postMutated = client[method].toString()
+
+    expect(postMutated).not.toBe(preMutated)
+  })
+})
+
+it('calls the original method', async () => {
+  const client = mockClient()
+  autoRetry(client)
+
+  const params = {
+    hello: 'world',
+  }
+  await client[client.methodName](params).catch(() => {})
+
+  expect(client.mockReference).toHaveBeenCalledWith(params)
+})
+
+it('lists temporary exceptions', () => {
+  expect(retryableExceptions).toBeInstanceOf(Array)
+})
+
+it('unknown exceptions bubble', async () => {
+  const client = mockClient()
+  client.mockReference.mockRejectedValueOnce(new Error('Mega Exception!'))
+  autoRetry(client)
+
+  const clientCall = client[client.methodName]()
+  await expect(clientCall).rejects.toThrow('Mega Exception!')
+})
+
+it('temporary exceptions are intercepted and retried', async () => {
+  const client = mockClient()
+
+  // An error with the name property
+  const errWithName = new Error('Super Crazy Error Occurred')
+  errWithName.name = 'ThrottlingException'
+
+  // An error with a named constructor
+  class ProvisionedThroughputExceededException extends Error {}
+  const errWithConstructor = new ProvisionedThroughputExceededException()
+
+  // And the final "db result"
+  const expectedFinalResult = 'World Peace'
+
+  client.mockReference
+    .mockRejectedValueOnce(errWithName)
+    .mockRejectedValueOnce(errWithConstructor)
+    .mockResolvedValueOnce(expectedFinalResult)
+
+  autoRetry(client)
+  const clientCall = client[client.methodName]()
+  await expect(clientCall).toResolve()
+
+  expect(sleep).toHaveBeenCalledTimes(2)
+  expect(client.mockReference).toHaveBeenCalledTimes(3)
+  await expect(clientCall).resolves.toBe(expectedFinalResult)
+})
+
+it('backs off on consecutive temporaries', async () => {
+  const client = mockClient()
+  autoRetry(client)
+
+  // Generate a bunch of errors
+  const errors = retryableExceptions.map((errorName) => {
+    const err = new Error(`An annoying ${errorName}`)
+    err.name = errorName
+    return err
+  })
+  errors.forEach(err => client.mockReference.mockRejectedValueOnce(err))
+  client.mockReference.mockResolvedValueOnce('Yay.')
+
+  // Call the client
+  const clientCall = client[client.methodName]()
+  await expect(clientCall).toResolve()
+
+  // Verify our backoff worked by looking at mirrored return val from our mock
+  expect(sleep).toHaveBeenCalledTimes(errors.length)
+  const sleepValues = await Promise.all(sleep.mock.results.map(res => res.value))
+  expect(sleepValues).toHaveLength(errors.length)
+  sleepValues.forEach((val, i) => {
+    if (!i) return
+    expect(val).toBeGreaterThan(sleepValues[i - 1])
+  })
+})

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -1,0 +1,100 @@
+
+const { EventEmitter } = require('events')
+
+/**
+ * recursion
+ * /rɪˈkəːʃ(ə)n/
+ *
+ * Did you mean: Recursion
+ *
+ * @see https://www.google.com/search?q=Recursion
+ */
+const scanRecursor = async (passalongs, chunkCallback) => {
+  const { client, scanParams } = passalongs
+
+  const data = await client.scan(scanParams)
+  await chunkCallback(data)
+
+  // continue scanning if we have more items
+  if (data.LastEvaluatedKey) {
+    scanParams.ExclusiveStartKey = data.LastEvaluatedKey
+    scanRecursor(passalongs, chunkCallback)
+  }
+}
+
+/**
+ * Adds "all()" method for loading an entire table into an array.
+ */
+exports.appendAll = (client) => {
+  /**
+   * Scan a table into memory.
+   *
+   * @param {DynamoDB.Types.ScanInput}
+   * @returns {Promise<Array>} Resolves with an array of Items
+   */
+  client.all = async (scanParams = {}) => {
+    return new Promise((resolve, reject) => {
+      const items = []
+      try {
+        scanRecursor(scanParams, async (data) => {
+          data.Items.forEach(item => items.push(item))
+          if (!data.LastEvaluatedKey) resolve(items)
+        })
+      } catch (err) {
+        reject(err)
+      }
+    })
+  }
+}
+
+/**
+ * Adds "stream()" and "streamSync()", recursive
+ * alternatives to scan() that use EventEmitter.
+ */
+exports.appendStream = (client) => {
+  /**
+   * Returns an EventEmitter that you can subscribe on to be
+   * notified of each batch of items from the table. This is
+   * an especially useful feature when dealing with enormous
+   * datasets that wont fit in memory but don't want to
+   * implement your own pagination to deal with chunks.
+   *
+   * @param {DynamoDB.Types.ScanInput}
+   * @returns {EventEmitter} emits "data", "items", "done" and "error" events
+   */
+  client.stream = (scanParams = {}) => {
+    const emitter = new EventEmitter()
+    try {
+      scanRecursor({ client, scanParams }, async (data) => {
+        emitter.emit('data', data)
+        emitter.emit('items', data.Items)
+
+        if (!data.LastEvaluatedKey) emitter.emit('done')
+      })
+    } catch (err) {
+      emitter.emit('error', err)
+    }
+    return emitter
+  }
+
+  /**
+   * Similar to stream, but waits for all eventlisteners to resolve before recursing the next batch. (This means listeners MUST return promises)
+   *
+   * @param {DynamoDB.Types.ScanInput}
+   * @returns {EventEmitter} emits "data", "items", "done" and "error" events
+   */
+  client.streamSync = (scanParams = {}) => {
+    const emitter = new EventEmitter()
+    try {
+      scanRecursor({ client, scanParams }, async (data) => {
+        await Promise.all(emitter.listeners('data').map((listener) => listener(data)))
+        await Promise.all(emitter.listeners('items').map((listener) => listener(data.Items)))
+
+        if (!data.LastEvaluatedKey) emitter.emit('done')
+      })
+    } catch (err) {
+      emitter.emit('error', err)
+    }
+    return emitter
+  }
+}

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -30,6 +30,7 @@ const scanEmitter = (client, scanParams, parallelScans, synchronous = false) => 
     // We only want to touch the request if explicitly told to,
     // they could be setting their own values for parallelism.
     if (parallelScans > 1) {
+      scanParams = { ...scanParams }
       scanParams.Segment = i
       scanParams.TotalSegments = parallelScans
     }

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -78,7 +78,7 @@ exports.appendStream = (client) => {
   }
 
   /**
-   * Similar to stream, but waits for all eventlisteners to resolve before recursing the next batch. (This means listeners MUST return promises)
+   * Similar to stream, but waits for all eventlisteners to resolve before recursing the next batch.
    *
    * @param {DynamoDB.Types.ScanInput}
    * @returns {EventEmitter} emits "data", "items", "done" and "error" events

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -22,17 +22,14 @@ const scanRecursor = async (passalongs, chunkCallback) => {
   }
 }
 
-/**
- * Adds "all()" method for loading an entire table into an array.
- */
-exports.appendAll = (client) => {
+module.exports = exports = (client) => {
   /**
    * Scan a table into memory.
    *
    * @param {DynamoDB.Types.ScanInput}
    * @returns {Promise<Array>} Resolves with an array of Items
    */
-  client.all = async (scanParams = {}) => {
+  client.scanAll = async (scanParams = {}) => {
     return new Promise((resolve, reject) => {
       const items = []
       try {
@@ -45,13 +42,7 @@ exports.appendAll = (client) => {
       }
     })
   }
-}
 
-/**
- * Adds "stream()" and "streamSync()", recursive
- * alternatives to scan() that use EventEmitter.
- */
-exports.appendStream = (client) => {
   /**
    * Returns an EventEmitter that you can subscribe on to be
    * notified of each batch of items from the table. This is
@@ -62,7 +53,7 @@ exports.appendStream = (client) => {
    * @param {DynamoDB.Types.ScanInput}
    * @returns {EventEmitter} emits "data", "items", "done" and "error" events
    */
-  client.stream = (scanParams = {}) => {
+  client.scanStream = (scanParams = {}) => {
     const emitter = new EventEmitter()
     try {
       scanRecursor({ client, scanParams }, async (data) => {
@@ -83,7 +74,7 @@ exports.appendStream = (client) => {
    * @param {DynamoDB.Types.ScanInput}
    * @returns {EventEmitter} emits "data", "items", "done" and "error" events
    */
-  client.streamSync = (scanParams = {}) => {
+  client.scanStreamSync = (scanParams = {}) => {
     const emitter = new EventEmitter()
     try {
       scanRecursor({ client, scanParams }, async (data) => {

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -67,7 +67,7 @@ exports.appendScanExtensions = (client) => {
     return new Promise((resolve, reject) => {
       const items = []
       try {
-        scanRecursor(scanParams, async (data) => {
+        scanRecursor({ client, scanParams }, async (data) => {
           data.Items.forEach(item => items.push(item))
           if (!data.LastEvaluatedKey) resolve(items)
         })

--- a/src/scanExtensions.spec.js
+++ b/src/scanExtensions.spec.js
@@ -1,6 +1,5 @@
 
 jest.doMock('./utils/allListeners', () => jest.fn(async (...input) => [...input]))
-const allListeners = require('./utils/allListeners')
 
 const mockClient = (method = 'scan') => {
   const methodMock = jest.fn(async () => ({ Items: [] }))


### PR DESCRIPTION
Appends new methods to the DocumentClient. Examples from the updated README:

**.scanAll()**

```js
const params = {
  TableName : 'MyTable',
  FilterExpression : 'Year = :this_year',
  ExpressionAttributeValues : {':this_year' : 2015}
}
const response = await documentClient.scanAll(params)
// response now contains ALL documents from 2015, not just the first 1MB
```

**.scanStream()**

```js
const params = {
  TableName : 'MyTable'
}
const emitter = documentClient.scanStream(params)
emitter.on('items', async (items) => {
  console.log(items)
})
```

**.scanStreamSync()**

```js
const params = {
  TableName : 'MyTable'
}
const emitter = documentClient.scanStreamSync(params)
emitter.on('items', async (items) => {
  // Do something async with the documents
  return Promise.all(items.map((item) => sendItemToSantaClaus(item)))
  // Once the Promise.all resolves, scanStreamSync() will automatically request the next batch.
})
```

