### PR TITLE
Parallel scans - Individual segment option overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To spread out the workload across your table partitions you can define a number 
 **Note:** scanStream() does not care whether your event listeners finish before it requests the next batch. (It will, however, respect throttling exceptions from DynamoDB.) If you want to control the pace, see [scanStreamSync](#methods-streamsync).
 
 - **params** - [AWS.DynamoDB.DocumentClient.scan() parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
-- **parallelScans** - _integer_ Amount of segments to split the scan operation into. (_Default: 1_)
+- **parallelScans** - _integer|array_ (_Default: 1_) Amount of segments to split the scan operation into. It also accepts an array of individual segment options such as LastEvaluatedKey, the length of the array then decides the amount of segments.
 
 The returned EventEmitter emits the following events:
 
@@ -185,7 +185,7 @@ emitter.on('items', async (items) => {
 Like `scanStream()`, but will not proceed to request the next batch until all eventlisteners have returned a value (or resolved, if they return a Promise).
 
 - **params** - [AWS.DynamoDB.DocumentClient.scan() parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
-- **parallelScans** - _integer_ Amount of segments to split the scan operation into. (_Default: 1_)
+- **parallelScans** - _integer|array_ (_Default: 1_) Amount of segments to split the scan operation into. It also accepts an array of individual segment options such as LastEvaluatedKey, the length of the array then decides the amount of segments.
 
 The returned EventEmitter emits the following events:
 
@@ -216,7 +216,7 @@ emitter.on('items', async (items) => {
 
 ### I need to use the regular client methods for some edge case.
 
-They are all available as `original_get` and similar:
+They are all available with an `original_` prefix:
 
 ```js
 const { DynamoPlus } = require('dynamo-plus')
@@ -228,7 +228,6 @@ documentClient.original_get(myParams).promise()
 ```
 
 Automatic retries don't apply when calling original methods directly.
-
 
 ### None of these questions seem to be questions.
 

--- a/src/scanExtensions.spec.js
+++ b/src/scanExtensions.spec.js
@@ -185,6 +185,28 @@ describe.each(['scanStream', 'scanStreamSync'])('%s()', (streamMethod) => {
     }, 10)
   })
 
+  it('sends option overrides to the various segments', (done) => {
+    expect.hasAssertions()
+    const client = mockClient()
+    appendScanExtensions(client)
+
+    const parallelScanOptions = [
+      {
+        LastEvaluatedKey: { foo: 'bar' }
+      },
+      {
+        LastEvaluatedKey: { hello: 'world' }
+      }
+    ]
+    client[streamMethod]({}, parallelScanOptions)
+
+    setTimeout(() => {
+      expect(client.mockReference).toHaveBeenCalledTimes(parallelScanOptions.length)
+      expect(client.scan.mock.toHaveBeenNthCalledWith(2, parallelScanOptions[1]))
+      done()
+    })
+  })
+
   it('only emits done when all segments have completed', (done) => {
     expect.hasAssertions()
     const client = mockClient()


### PR DESCRIPTION
Adds support for passing individual sets of options to the different segments when using scanStream() or scanStreamSync() by using an array of objects for the parallelScans parameter. If you only want to override _some_ of the segments' options, use an empty object or a falsy value as a placeholder, like so:

```js
const params = { TableName : 'MyTable' }

// This will result in 3 segments being spawned
const segments = [
  { LastEvaluatedKey: { houseId: 'abc123' } },
  undefined,
  {},
]
const emitter = documentClient.scanStream(params, segments)
```