### PR TITLE
Tests and fix for #3

### DIFF
--- a/src/errorPropagation.spec.js
+++ b/src/errorPropagation.spec.js
@@ -1,0 +1,44 @@
+
+jest.doMock('aws-sdk/clients/dynamodb', () => ({
+  DocumentClient: function () {
+    return mockClient()
+  }
+}))
+
+const { DynamoPlus } = require('./index')
+const clientMethods = jest.requireActual('./clientMethods')
+
+const mockClient = () => {
+  const methodMock = jest.fn(async () => ({ Item: {} }))
+  const client = {
+    originalMethodMock: methodMock,
+  }
+  clientMethods.forEach(method => {
+    client[method] = (params) => ({ promise: async () => methodMock(params) })
+  })
+  return client
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it.each(['deleteAll', 'putAll', 'scanAll', 'queryAll'])('%s() errors are catchable', async (method) => {
+  const client = DynamoPlus()
+  const expectedError = new Error(`Something scary occurred while calling ${method}`)
+  const expectedFallbackObject = { method, caughtError: 'true' }
+
+  // Make sure all the core Dynamo methods reject
+  client.originalMethodMock.mockRejectedValue(expectedError)
+
+  // 'Items' for putAll and 'Keys' for deleteAll
+  const methodCallPromise = client[method]({ Items: [1337], Keys: ['bbq'] })
+  await expect(methodCallPromise).toReject()
+
+  // Make sure we get the _expected_ error from our "original" Dynamo method
+  await expect(methodCallPromise).rejects.toBe(expectedError)
+
+  // Verify its a catchable rejection and doesnt end up unhandled somewhere in limbo
+  const result = await methodCallPromise.catch(() => expectedFallbackObject)
+  expect(result).toBe(expectedFallbackObject)
+})

--- a/src/queryExtensions.js
+++ b/src/queryExtensions.js
@@ -33,10 +33,10 @@ const queryEmitter = (client, queryParams, synchronous = false) => {
 
 exports.appendQueryExtensions = (client) => {
   client.queryAll = async (queryParams = {}) => {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       const items = []
       try {
-        queryRecursor({ client, queryParams }, async (data) => {
+        await queryRecursor({ client, queryParams }, async (data) => {
           data.Items.forEach(item => items.push(item))
           if (!data.LastEvaluatedKey) resolve(items)
         })

--- a/src/scanExtensions.js
+++ b/src/scanExtensions.js
@@ -48,10 +48,10 @@ const scanEmitter = (client, scanParams, parallelScans, synchronous = false) => 
 
 exports.appendScanExtensions = (client) => {
   client.scanAll = async (scanParams = {}) => {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       const items = []
       try {
-        scanRecursor({ client, scanParams }, async (data) => {
+        await scanRecursor({ client, scanParams }, async (data) => {
           data.Items.forEach(item => items.push(item))
           if (!data.LastEvaluatedKey) resolve(items)
         })


### PR DESCRIPTION
The scanAll() and queryAll() methods were susceptible to error leakage due to the way they combine traditional promise constructors and async-await syntax. This PR addresses that as well as adds tests for all the custom *All() methods to avoid regression.