### PR TITLE
Retry on InternalServerError. 

### DIFF
--- a/src/retryableExceptions.js
+++ b/src/retryableExceptions.js
@@ -5,6 +5,7 @@ const sleep = require('./utils/sleep')
 // Throttling-related exceptions
 // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes
 const retryableExceptions = [
+  'InternalServerError',
   'LimitExceededException',
   'ProvisionedThroughputExceededException',
   'RequestLimitExceeded',


### PR DESCRIPTION
We're making an assumption that in the wild we'll only be seeing the Error constructor name "InternalServerError" in PascalCase when they originate specifically from AWS. 

Closes #16