### PR TITLE
getAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ const data = await documentClient.get(regularDynamoParams)
 
 - automatically appends .promise()
 - automatically retries and backs off when you get throttled
+- new method for performing batchGet requests in chunks
+  - [getAll(params)](#methods-getall)
 - new methods for performing batchWrite requests in chunks
   - [deleteAll(params)](#methods-deleteall)
   - [putAll(params)](#methods-putall)
@@ -56,6 +58,32 @@ Whenever a query fails for reasons such as `LimitExceededException` the promise 
 For information about retryable exceptions, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes
 
 If you want to use a delay from the beginning, set `lastBackOff` to a millisecond value in the query params.
+
+## New method for performing batchGet requests in chunks
+
+The built-in _batchRead_ method can be used for fetching multiple documents by their primary keys, but it requires you to handle chunking and unprocessed items yourself. DynamoPlus adds a _getAll_ method that does the heavy lifting for you.
+
+<a name="methods-getall"></a>
+### getAll(params)
+
+It's like _batchGet_, but with the simple syntax of _get_.
+
+- **params** `Object`
+  - **TableName**
+  - **Keys** - An array of key objects equivalent to `Key` in _get()_.
+  - **BatchSize** - Optional custom batch size. Defaults to 100 which the maximum permitted value by DynamoDB.
+
+_getAll()_ returns
+
+```js
+const params = {
+  TableName: 'users',
+  Keys: [{ userId: '1' }, { userId: '2' }, /* ... */ { userId: '999' }]
+}
+
+const response = await documentClient.getAll(params)
+// response now contains ALL documents, not just the first 100
+```
 
 ## New methods for performing batchWrite requests in chunks
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,13 @@ export class DynamoPlusClient extends DocumentClient {
   // -- Custom methods  w/ handcrafted typings below this line. --
 
   /**
+   * Similar to get(), but takes a Keys array pointing to multiple documents to be removed.
+   *
+   * It will automatically perform an unlimited amount of batchWrite() requests until the list has been processed.
+   */
+   getAll(params: GetAllRequest): Promise<DocumentClient.ItemList>
+
+  /**
    * Similar to delete(), but takes a Keys array pointing to multiple documents to be removed.
    *
    * It will automatically perform an unlimited amount of batchWrite() requests until the list has been processed.
@@ -100,6 +107,20 @@ export class DynamoPlusClient extends DocumentClient {
    * Similar to queryStream(), but waits for all eventlisteners to resolve before reading the next page.
    */
   queryStreamSync(params: DocumentClient.QueryInput): QueryEmitterSynchronous
+}
+
+export interface GetAllRequest {
+  TableName: string
+
+  /**
+   * An unlimited amount of keys to fetch.
+   */
+  Keys: DocumentClient.Key[]
+
+  /**
+   * The amount of requests to write per batch. Defaults to the DynamoDB maximum of 100.
+   */
+  BatchSize: Number
 }
 
 export interface DeleteAllRequest {

--- a/src/getAll.js
+++ b/src/getAll.js
@@ -1,0 +1,28 @@
+const batchReadRetry = require('./utils/batchGetRetry')
+const chunk = require('./utils/chunk')
+
+exports.appendGetAll = (client) => {
+  client.getAll = async (params = {}) => {
+    const {
+      TableName = '',
+      Keys = [],
+      BatchSize = 100,
+    } = params
+
+    const batches = chunk(Keys, BatchSize)
+
+    // Build a chain of batchWrite operations
+    return batches.reduce(async (chain, batch) => {
+      const previousResults = await chain
+
+      const output = await batchReadRetry(client, {
+        RequestItems: {
+          [TableName]: {
+            Keys: batch,
+          },
+        },
+      })
+      return previousResults.concat(...output[TableName])
+    }, [])
+  }
+}

--- a/src/getAll.spec.js
+++ b/src/getAll.spec.js
@@ -1,0 +1,93 @@
+
+const mockClient = (method = 'batchGet') => {
+  const methodMock = jest.fn(async ({ RequestItems }) => {
+    const TableName = Object.keys(RequestItems)[0]
+    return { Responses: { [TableName]: [] }, UnprocessedKeys: {} }
+  })
+  return {
+    mockReference: methodMock,
+    methodName: method,
+    [method]: methodMock,
+  }
+}
+
+const { appendGetAll } = require('./getAll')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('appendGetAll()', () => {
+  it('appends getAll() to DocumentClient', () => {
+    const client = mockClient()
+
+    appendGetAll(client)
+
+    expect(client).toHaveProperty('getAll')
+    expect(client.getAll).toBeInstanceOf(Function)
+  })
+})
+
+describe('getAll()', () => {
+  it('returns a Promise', () => {
+    const client = mockClient()
+    appendGetAll(client)
+
+    expect(client.getAll()).toBeInstanceOf(Promise)
+  })
+
+  it('builds appropriate batchGet params', async () => {
+    const client = mockClient()
+    appendGetAll(client)
+
+    const TableName = 'Woop woop!'
+    const Keys = [{ a: 'b' }, { c: 'd' }]
+    await client.getAll({ TableName, Keys })
+
+    expect(client.mockReference.mock.calls[0][0]).toStrictEqual(
+      { RequestItems: { [TableName]: { Keys } } }
+    )
+  })
+
+  it('chunks documents to 100 per batchGet by default', async () => {
+    const client = mockClient()
+    appendGetAll(client)
+
+    let Keys = []
+    for (let i = 0; i < 123; i++) {
+      Keys.push({ documentNumber: `doc-${i}` })
+    }
+    await client.getAll({ Keys })
+
+    expect(client.mockReference).toHaveBeenCalledTimes(Math.ceil(Keys.length / 100))
+  })
+
+  it('allows batch size to be overridden', async () => {
+    const BatchSize = 10
+    const client = mockClient()
+    appendGetAll(client)
+
+    let Keys = []
+    for (let i = 0; i < 123; i++) {
+      Keys.push({ documentNumber: `doc-${i}` })
+    }
+    await client.getAll({ BatchSize, Keys })
+
+    expect(client.mockReference).toHaveBeenCalledTimes(Math.ceil(Keys.length / 10))
+  })
+
+  it('resolves with a compiled list of documents', async () => {
+    const BatchSize = 1
+    const client = mockClient()
+    appendGetAll(client)
+
+    const Keys = [{ foo: 1 }, { bar: 2 }]
+    Keys.forEach((document) => {
+      client.mockReference.mockResolvedValueOnce({ Responses: { '': [document] }, UnprocessedKeys: {} })
+    })
+
+    const results = await client.getAll({ BatchSize, Keys })
+
+    expect(results).toEqual(Keys)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,9 @@ const {
   retryableExceptions,
 } = require('./retryableExceptions')
 const {
+  appendGetAll,
+} = require('./getAll')
+const {
   appendDeleteAll,
 } = require('./deleteAll')
 const {
@@ -22,6 +25,7 @@ const clientConstructor = (options = {}) => {
   const dynamoClient = new DynamoDB.DocumentClient(options)
   promisifyDocumentClient(dynamoClient)
   autoRetry(dynamoClient)
+  appendGetAll(dynamoClient)
   appendDeleteAll(dynamoClient)
   appendPutAll(dynamoClient)
   appendQueryExtensions(dynamoClient)

--- a/src/utils/batchGetRetry.js
+++ b/src/utils/batchGetRetry.js
@@ -1,0 +1,17 @@
+
+const batchReadRetry = async (client, getParams) => {
+  const { Responses = {}, UnprocessedKeys = {} } = await client.batchGet(getParams)
+
+  if (Object.keys(UnprocessedKeys).length) {
+    // Retry and merge the output
+    const retriedResponses = await batchReadRetry(client, { ...getParams, RequestItems: UnprocessedKeys })
+
+    Object.keys(retriedResponses).forEach((tableName) => {
+      if (!Responses[tableName]) Responses[tableName] = []
+      Responses[tableName].push(...retriedResponses[tableName])
+    })
+  }
+  return Responses
+}
+
+module.exports = exports = batchReadRetry

--- a/src/utils/batchGetRetry.spec.js
+++ b/src/utils/batchGetRetry.spec.js
@@ -1,0 +1,48 @@
+
+const mockClient = (method = 'batchGet') => {
+  const methodMock = jest.fn(async () => ({ UnprocessedItems: {} }))
+  return {
+    mockReference: methodMock,
+    methodName: method,
+    [method]: methodMock,
+  }
+}
+
+const batchGetRetry = require('./batchGetRetry')
+
+describe('batchGetRetry()', () => {
+  it('returns a Promise', async () => {
+    const client = mockClient()
+
+    expect(batchGetRetry(client)).toBeInstanceOf(Promise)
+  })
+
+  it('forwards params to the client', async () => {
+    const client = mockClient()
+
+    const TableName = 'Area51'
+    const params = { RequestItems: { [TableName]: [] } }
+    await batchGetRetry(client, params)
+
+    expect(client.mockReference).toHaveBeenCalledWith(params)
+  })
+
+  it('retries unprocessed keys', async () => {
+    const client = mockClient()
+
+    const TableName = 'Area51'
+    const Item = {
+      id: 'foo',
+      name: 'Matthew',
+    }
+    const RequestItems = { [TableName]: [{ PutRequest: { Item } }] }
+
+    // Make sure it fails once.
+    client.mockReference.mockResolvedValueOnce({ UnprocessedKeys: RequestItems })
+
+    const params = { RequestItems }
+    await batchGetRetry(client, params)
+
+    expect(client.mockReference).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Adds a `getAll()` method to intuitively fetch large sets of documents by key.

Closes #23.