### PR TITLE
Default to HTTP keep-alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ const data = await documentClient.get(regularDynamoParams)
 # Features
 
 - automatically appends .promise()
+- automatically enables HTTP keep-alive
 - automatically retries and backs off when you get throttled
 - new method for performing batchGet requests in chunks
   - [getAll(params)](#methods-getall)
@@ -47,9 +48,13 @@ const data = await documentClient.get(regularDynamoParams)
 
 ## Promises by default
 
-The DynamoPlus client will automatically append `.promise()` for you, making all methods awaitable by default.
+The DynamoPlus client will automatically append `.promise()` for you, making all methods `await`able by default.
 
 When the client is instantiated, the original methods are prefixed and accessible through e.g. ``original_${method}``
+
+## HTTP keep-alive by default
+
+Setting up TCP connections is slow and costly, especially when you need to perform multiple operations in a row. Enabling HTTP keep-alive can reduce latency by [up to 70%](https://theburningmonk.com/2019/02/lambda-optimization-tip-enable-http-keep-alive/), but the v2 SDK doesn't enable it by default. DynamoPlus takes care of the boilerplate for you.
 
 ## Retries and backoff
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
-import { DocumentClient } from 'aws-sdk/clients/dynamodb'
-import { on } from 'cluster';
-import { appendPutAll } from './src/putAll';
+import DynamoDB, { DocumentClient } from 'aws-sdk/clients/dynamodb'
 
 export class DynamoPlusClient extends DocumentClient {
   /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -18,9 +18,26 @@ it('has DynamoPlus property', () => {
   expect(dp).toHaveProperty('DynamoPlus')
 })
 
-it('DynamoPlus() returns a new DocumentClient', () => {
-  const { DynamoPlus } = requireUncached(`./index`)
-  const client = DynamoPlus()
+describe('DynamoPlus', () => {
+  it('returns a new DocumentClient', () => {
+    const { DynamoPlus } = requireUncached(`./index`)
 
-  expect(client.constructor.name).toBe('DocumentClient')
+    const client = DynamoPlus()
+
+    expect(client.constructor.name).toBe('DocumentClient')
+  })
+  it('allows custom options', () => {
+    const { DynamoPlus } = requireUncached(`./index`)
+
+    const client = DynamoPlus({ potato: 'Hello' })
+
+    expect(client.service.config.potato).toBe('Hello')
+  })
+  it('defaults to a keepalive-enabled http agent', () => {
+    const { DynamoPlus } = requireUncached(`./index`)
+
+    const client = DynamoPlus()
+
+    expect(client.service.config.httpOptions).toMatchObject({ agent: { keepAlive: true } })
+  })
 })


### PR DESCRIPTION
Overrides the default HTTP agent with a keepalive-enabled one unless a user specifically sets `options.httpAgent.agent`.

Closes #21.