### PR TITLE
Dont inject keep-alive when endpoint has been overridden

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,14 @@ const {
 } = require('./scanExtensions')
 
 const clientConstructor = (options = {}) => {
-  const keepaliveAgent = new https.Agent({
-    keepAlive: true,
-  })
+  // Only inject our custom agent with HTTP keep-alive if user hasn't manually defined endpoint or agent
+  let keepaliveAgent
+  if (!options.endpoint) {
+    keepaliveAgent = new https.Agent({
+      keepAlive: true,
+    })
+  }
+
   const clientOptions = {
     ...options,
     httpOptions: {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -26,6 +26,7 @@ describe('DynamoPlus', () => {
 
     expect(client.constructor.name).toBe('DocumentClient')
   })
+
   it('allows custom options', () => {
     const { DynamoPlus } = requireUncached(`./index`)
 
@@ -33,11 +34,40 @@ describe('DynamoPlus', () => {
 
     expect(client.service.config.potato).toBe('Hello')
   })
-  it('defaults to a keepalive-enabled http agent', () => {
+
+  it('defaults to using a keepalive-enabled https agent', () => {
     const { DynamoPlus } = requireUncached(`./index`)
 
     const client = DynamoPlus()
 
-    expect(client.service.config.httpOptions).toMatchObject({ agent: { keepAlive: true } })
+    const clientConfig = client.service.config
+    const apiRequest = client.get({ TableName: 'test', Key: { id: 'test' } })
+
+    expect(clientConfig.httpOptions).toMatchObject({ agent: { keepAlive: true } })
+    expect(apiRequest).toMatchObject({ service: { config: { httpOptions: { agent: { keepAlive: true } } } } })
+  })
+
+  it('does not set an agent if a custom endpoint is defined', async () => {
+    const { DynamoPlus } = requireUncached(`./index`)
+
+    const client = DynamoPlus({ region: 'eu-west-1', endpoint: 'http://localhost:7171/' })
+
+    const clientConfig = client.service.config
+    const apiRequest = client.get({ TableName: 'test', Key: { id: 'test' } })
+
+    expect(clientConfig.httpOptions).toMatchObject({ agent: undefined })
+    expect(apiRequest).toMatchObject({ service: { config: { httpOptions: { agent: undefined } } } })
+  })
+
+  it('allows an explicitly undefined http(s) agent', async () => {
+    const { DynamoPlus } = requireUncached(`./index`)
+
+    const client = DynamoPlus({ region: 'eu-west-1', httpOptions: { agent: undefined } })
+
+    const clientConfig = client.service.config
+    const apiRequest = client.get({ TableName: 'test', Key: { id: 'test' } })
+
+    expect(clientConfig.httpOptions).toMatchObject({ agent: undefined })
+    expect(apiRequest).toMatchObject({ service: { config: { httpOptions: { agent: undefined } } } })
   })
 })


### PR DESCRIPTION
As pointed out in the [discussion on 14e2dd4](https://github.com/Sleavely/dynamo-plus/commit/14e2dd4c04728860439002bbe27e6c16aaf7efdf#all_commit_comments) the automatic setting of `keep-alive` forces the agent to use HTTPS. For use with AWS' own DynamoDB APIs this is not an issue, but some of the reverse-engineered implementations of DynamoDB for local development and testing only support HTTP.