### PR TITLE
Specify aws-sdk only as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ emitter.on('items', async (items) => {
 
 ### I'm getting errors that the `aws-sdk` module isn't installed.
 
-`aws-sdk` is set as a dev-dependency since it is pretty large and installed by default on AWS Lambda.
+`aws-sdk` is specified as a [peer dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies) since it is pretty large and installed by default on AWS Lambda.
 
 ### I need to use the regular client methods for some edge case.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.9.1",
-    "aws-sdk": "^2.639.0",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.20.1",
@@ -32,7 +31,7 @@
     "jest-extended": "^0.11.5"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.200.0"
+    "aws-sdk": "2.x"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
If `aws-sdk` is declared as a peer dependency it probably makes little sense to also have it listed as a dev dependency.