### PR TITLE
Improved stack traces

### DIFF
--- a/src/promisifyDocumentClient.js
+++ b/src/promisifyDocumentClient.js
@@ -16,7 +16,12 @@ const promisifyDocumentClient = (client) => {
 
     client[`original_${method}`] = client[method]
     client[method] = async (params = {}) => {
-      return client[`original_${method}`](params).promise()
+      return client[`original_${method}`](params)
+        .promise()
+        .catch(err => {
+          err.stack = (new err.constructor(err.message).stack)
+          throw err
+        })
     }
   })
 }


### PR DESCRIPTION
As described in #37, default `aws-sdk` stack traces usually don't give away the source of the problem. This feature will shortcircuit the stack to end prior to reaching the SDK, leaving plenty of room to trace the call back to the developers own app.